### PR TITLE
refactor: modularize game entities

### DIFF
--- a/src/entities/BaseSprite.ts
+++ b/src/entities/BaseSprite.ts
@@ -1,0 +1,45 @@
+import { Point2D, Rect } from "../utils";
+
+export default class BaseSprite {
+  protected ctx: CanvasRenderingContext2D;
+  img: HTMLImageElement;
+  position: Point2D;
+  scale: Point2D;
+  bounds: Rect;
+  doLogic: boolean;
+
+  constructor(
+    ctx: CanvasRenderingContext2D,
+    img: HTMLImageElement,
+    x: number,
+    y: number,
+  ) {
+    this.ctx = ctx;
+    this.img = img;
+    this.position = new Point2D(x, y);
+    this.scale = new Point2D(1, 1);
+    this.bounds = new Rect(x, y, this.img.width, this.img.height);
+    this.doLogic = true;
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  update(dt: number, ...args: any[]) {}
+
+  protected _updateBounds() {
+    this.bounds.set(
+      this.position.x,
+      this.position.y,
+      ~~(0.5 + this.img.width * this.scale.x),
+      ~~(0.5 + this.img.height * this.scale.y),
+    );
+  }
+
+  protected _drawImage() {
+    this.ctx.drawImage(this.img, this.position.x, this.position.y);
+  }
+
+  draw(resized: boolean) {
+    this._updateBounds();
+    this._drawImage();
+  }
+}

--- a/src/entities/Bullet.ts
+++ b/src/entities/Bullet.ts
@@ -1,0 +1,33 @@
+import BaseSprite from "./BaseSprite";
+
+export default class Bullet extends BaseSprite {
+  direction: number;
+  speed: number;
+  alive: boolean;
+
+  constructor(
+    ctx: CanvasRenderingContext2D,
+    img: HTMLImageElement,
+    x: number,
+    y: number,
+    direction: number,
+    speed: number,
+  ) {
+    super(ctx, img, x, y);
+    this.direction = direction;
+    this.speed = speed;
+    this.alive = true;
+  }
+
+  update(dt: number) {
+    this.position.y -= this.speed * this.direction * dt;
+
+    if (this.position.y < 0) {
+      this.alive = false;
+    }
+  }
+
+  draw(resized: boolean) {
+    super.draw(resized);
+  }
+}

--- a/src/entities/Enemy.ts
+++ b/src/entities/Enemy.ts
@@ -1,0 +1,99 @@
+import SheetSprite from "./SheetSprite";
+import Bullet from "./Bullet";
+import { ClipRect, getRandomArbitrary } from "../utils";
+
+export interface EnemyUpdateOptions {
+  alienDirection: number;
+  setUpdateAlienLogic: () => void;
+  canvasWidth: number;
+  reset: () => void;
+  alienYDown: number;
+}
+
+export default class Enemy extends SheetSprite {
+  clipRects: ClipRect[];
+  onFirstState: boolean;
+  stepDelay: number;
+  stepAccumulator: number;
+  doShoot: boolean;
+  bullet?: Bullet;
+  alive: boolean;
+  private bulletImg: HTMLImageElement;
+
+  constructor(
+    ctx: CanvasRenderingContext2D,
+    spriteSheetImg: HTMLImageElement,
+    bulletImg: HTMLImageElement,
+    clipRects: ClipRect[],
+    x: number,
+    y: number,
+  ) {
+    super(ctx, spriteSheetImg, clipRects[0], x, y);
+    this.bulletImg = bulletImg;
+    this.clipRects = clipRects;
+    this.scale.set(0.5, 0.5);
+    this.alive = true;
+    this.onFirstState = true;
+    this.stepDelay = 1;
+    this.stepAccumulator = 0;
+    this.doShoot = false;
+    this.bullet = undefined;
+  }
+
+  toggleFrame() {
+    this.onFirstState = !this.onFirstState;
+    this.clipRect = this.onFirstState ? this.clipRects[0] : this.clipRects[1];
+  }
+
+  shoot() {
+    this.bullet = new Bullet(
+      this.ctx,
+      this.bulletImg,
+      this.position.x,
+      this.position.y + this.bounds.w / 2,
+      -1,
+      500,
+    );
+  }
+
+  update(dt: number, opts: EnemyUpdateOptions) {
+    this.stepAccumulator += dt;
+
+    if (this.stepAccumulator >= this.stepDelay) {
+      if (this.position.x < this.bounds.w / 2 + 20 && opts.alienDirection < 0) {
+        opts.setUpdateAlienLogic();
+      }
+      if (
+        opts.alienDirection === 1 &&
+        this.position.x > opts.canvasWidth - this.bounds.w / 2 - 20
+      ) {
+        opts.setUpdateAlienLogic();
+      }
+      if (this.position.y > opts.canvasWidth - 50) {
+        opts.reset();
+      }
+
+      const fireTest = Math.floor(Math.random() * (this.stepDelay + 1));
+      if (getRandomArbitrary(0, 1000) <= 5 * (this.stepDelay + 1)) {
+        this.doShoot = true;
+      }
+      this.position.x += 10 * opts.alienDirection;
+      this.toggleFrame();
+      this.stepAccumulator = 0;
+    }
+    this.position.y += opts.alienYDown;
+
+    if (this.bullet && this.bullet.alive) {
+      this.bullet.update(dt);
+    } else {
+      this.bullet = undefined;
+    }
+  }
+
+  draw(resized: boolean) {
+    super.draw(resized);
+    if (this.bullet !== undefined && this.bullet.alive) {
+      this.bullet.draw(resized);
+    }
+  }
+}

--- a/src/entities/ParticleExplosion.ts
+++ b/src/entities/ParticleExplosion.ts
@@ -1,0 +1,87 @@
+export default class ParticleExplosion {
+  private ctx: CanvasRenderingContext2D;
+  particlePool: any[];
+  particles: any[];
+
+  constructor(ctx: CanvasRenderingContext2D) {
+    this.ctx = ctx;
+    this.particlePool = [];
+    this.particles = [];
+  }
+
+  draw() {
+    for (let i = this.particles.length - 1; i >= 0; i--) {
+      const particle = this.particles[i];
+      particle.moves++;
+      particle.x += particle.xunits;
+      particle.y += particle.yunits + particle.gravity * particle.moves;
+      particle.life--;
+
+      if (particle.life <= 0) {
+        if (this.particlePool.length < 100) {
+          this.particlePool.push(this.particles.splice(i, 1));
+        } else {
+          this.particles.splice(i, 1);
+        }
+      } else {
+        this.ctx.globalAlpha = particle.life / particle.maxLife;
+        this.ctx.fillStyle = particle.color;
+        this.ctx.fillRect(particle.x, particle.y, particle.width, particle.height);
+        this.ctx.globalAlpha = 1;
+      }
+    }
+  }
+
+  createExplosion(
+    x: number,
+    y: number,
+    color: string,
+    number: number,
+    width: number,
+    height: number,
+    spd: number,
+    grav: number,
+    lif: number,
+  ) {
+    for (let i = 0; i < number; i++) {
+      const angle = Math.floor(Math.random() * 360);
+      const speed = Math.floor((Math.random() * spd) / 2) + spd;
+      const life = Math.floor(Math.random() * lif) + lif / 2;
+      const radians = (angle * Math.PI) / 180;
+      const xunits = Math.cos(radians) * speed;
+      const yunits = Math.sin(radians) * speed;
+
+      if (this.particlePool.length > 0) {
+        const tempParticle = this.particlePool.pop();
+        tempParticle.x = x;
+        tempParticle.y = y;
+        tempParticle.xunits = xunits;
+        tempParticle.yunits = yunits;
+        tempParticle.life = life;
+        tempParticle.color = color;
+        tempParticle.width = width;
+        tempParticle.height = height;
+        tempParticle.gravity = grav;
+        tempParticle.moves = 0;
+        tempParticle.alpha = 1;
+        tempParticle.maxLife = life;
+        this.particles.push(tempParticle);
+      } else {
+        this.particles.push({
+          x: x,
+          y: y,
+          xunits: xunits,
+          yunits: yunits,
+          life: life,
+          color: color,
+          width: width,
+          height: height,
+          gravity: grav,
+          moves: 0,
+          alpha: 1,
+          maxLife: life,
+        });
+      }
+    }
+  }
+}

--- a/src/entities/Player.ts
+++ b/src/entities/Player.ts
@@ -1,0 +1,116 @@
+import SheetSprite from "./SheetSprite";
+import Bullet from "./Bullet";
+import { ClipRect, clamp } from "../utils";
+
+export default class Player extends SheetSprite {
+  lives: number;
+  xVel: number;
+  bullets: Bullet[];
+  bulletDelayAccumulator: number;
+  score: number;
+  private canvasWidth: number;
+  private canvasHeight: number;
+  private bulletImg: HTMLImageElement;
+  private playSound: (name: string) => void;
+  private isKeyDown: (key: number) => boolean;
+  private wasKeyPressed: (key: number) => boolean;
+  private keys: { left: number; right: number; shoot: number };
+
+  constructor(
+    ctx: CanvasRenderingContext2D,
+    spriteSheetImg: HTMLImageElement,
+    clipRect: ClipRect,
+    canvasWidth: number,
+    canvasHeight: number,
+    bulletImg: HTMLImageElement,
+    playSound: (name: string) => void,
+    isKeyDown: (key: number) => boolean,
+    wasKeyPressed: (key: number) => boolean,
+    keys: { left: number; right: number; shoot: number },
+  ) {
+    super(ctx, spriteSheetImg, clipRect, canvasWidth / 2, canvasHeight - 70);
+    this.scale.set(0.85, 0.85);
+    this.lives = 3;
+    this.xVel = 0;
+    this.bullets = [];
+    this.bulletDelayAccumulator = 0;
+    this.score = 0;
+    this.canvasWidth = canvasWidth;
+    this.canvasHeight = canvasHeight;
+    this.bulletImg = bulletImg;
+    this.playSound = playSound;
+    this.isKeyDown = isKeyDown;
+    this.wasKeyPressed = wasKeyPressed;
+    this.keys = keys;
+  }
+
+  reset() {
+    this.lives = 3;
+    this.score = 0;
+    this.position.set(this.canvasWidth / 2, this.canvasHeight - 70);
+  }
+
+  shoot() {
+    const bullet = new Bullet(
+      this.ctx,
+      this.bulletImg,
+      this.position.x,
+      this.position.y - this.bounds.h / 2,
+      1,
+      1000,
+    );
+    this.bullets.push(bullet);
+    this.playSound("shoot");
+  }
+
+  handleInput() {
+    if (this.isKeyDown(this.keys.left)) {
+      this.xVel = -175;
+    } else if (this.isKeyDown(this.keys.right)) {
+      this.xVel = 175;
+    } else this.xVel = 0;
+
+    if (this.wasKeyPressed(this.keys.shoot)) {
+      if (this.bulletDelayAccumulator > 0.5) {
+        this.shoot();
+        this.bulletDelayAccumulator = 0;
+      }
+    }
+  }
+
+  updateBullets(dt: number) {
+    for (let i = this.bullets.length - 1; i >= 0; i--) {
+      let bullet = this.bullets[i];
+      if (bullet.alive) {
+        bullet.update(dt);
+      } else {
+        this.bullets.splice(i, 1);
+        bullet = undefined as any;
+      }
+    }
+  }
+
+  update(dt: number) {
+    this.bulletDelayAccumulator += dt;
+
+    this.position.x += this.xVel * dt;
+
+    this.position.x = clamp(
+      this.position.x,
+      this.bounds.w / 2,
+      this.canvasWidth - this.bounds.w / 2,
+    );
+    this.updateBullets(dt);
+  }
+
+  draw(resized: boolean) {
+    super.draw(resized);
+
+    for (let i = 0, len = this.bullets.length; i < len; i++) {
+      const bullet = this.bullets[i];
+      if (bullet.alive) {
+        bullet.draw(resized);
+      }
+    }
+  }
+}

--- a/src/entities/SheetSprite.ts
+++ b/src/entities/SheetSprite.ts
@@ -1,0 +1,55 @@
+import BaseSprite from "./BaseSprite";
+import { ClipRect } from "../utils";
+
+export default class SheetSprite extends BaseSprite {
+  clipRect: ClipRect;
+
+  constructor(
+    ctx: CanvasRenderingContext2D,
+    sheetImg: HTMLImageElement,
+    clipRect: ClipRect,
+    x: number,
+    y: number,
+  ) {
+    super(ctx, sheetImg, x, y);
+    this.clipRect = clipRect;
+    this.bounds.set(x, y, this.clipRect.w, this.clipRect.h);
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  update(dt: number, ...args: any[]) {}
+
+  protected _updateBounds() {
+    const w = ~~(0.5 + this.clipRect.w * this.scale.x);
+    const h = ~~(0.5 + this.clipRect.h * this.scale.y);
+    this.bounds.set(this.position.x - w / 2, this.position.y - h / 2, w, h);
+  }
+
+  protected _drawImage() {
+    this.ctx.save();
+    this.ctx.transform(
+      this.scale.x,
+      0,
+      0,
+      this.scale.y,
+      this.position.x,
+      this.position.y,
+    );
+    this.ctx.drawImage(
+      this.img,
+      this.clipRect.x,
+      this.clipRect.y,
+      this.clipRect.w,
+      this.clipRect.h,
+      ~~(0.5 + -this.clipRect.w * 0.5),
+      ~~(0.5 + -this.clipRect.h * 0.5),
+      this.clipRect.w,
+      this.clipRect.h,
+    );
+    this.ctx.restore();
+  }
+
+  draw(resized: boolean) {
+    super.draw(resized);
+  }
+}


### PR DESCRIPTION
## Summary
- extract sprite and game entity classes into dedicated modules
- update game logic to instantiate entities from the new modules
- adapt alien update flow for injected game state

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Cannot find module 'react' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68a7ade620d48323ab022b748794a7ba