### PR TITLE
refactor: use hook to start game

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,14 +1,8 @@
-import { useEffect, useRef } from 'react';
-import { startGame } from './game';
+import { useRef } from 'react';
+import { useSpaceInvaders } from './hooks/useSpaceInvaders';
 
 export default function App() {
   const canvasRef = useRef<HTMLCanvasElement>(null);
-
-  useEffect(() => {
-    if (canvasRef.current) {
-      startGame({ canvas: canvasRef.current, autoPlay: true });
-    }
-  }, []);
-
+  useSpaceInvaders(canvasRef, { autoPlay: true });
   return <canvas ref={canvasRef} />;
 }

--- a/src/hooks/useSpaceInvaders.ts
+++ b/src/hooks/useSpaceInvaders.ts
@@ -1,0 +1,18 @@
+import { RefObject, useEffect, useState } from 'react';
+import { startGame, InvadersOptions } from '../game';
+
+export function useSpaceInvaders(
+  canvasRef: RefObject<HTMLCanvasElement>,
+  options: InvadersOptions = {}
+) {
+  const [started, setStarted] = useState(false);
+
+  useEffect(() => {
+    if (canvasRef.current && !started) {
+      startGame({ ...options, canvas: canvasRef.current });
+      setStarted(true);
+    }
+  }, [canvasRef, started, options]);
+
+  return started;
+}


### PR DESCRIPTION
## Summary
- modularize game startup into `useSpaceInvaders` hook using `useState` and `useEffect`
- simplify `App` component to use the hook

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build` *(fails: Cannot find type definition file for 'babel__generator', 'babel__template', 'babel__traverse', 'prop-types', 'react', 'react-dom')*

------
https://chatgpt.com/codex/tasks/task_e_68a7b0d7d8d48323bb9dc27025748e77