### PR TITLE
Adicionar som de tiro

### DIFF
--- a/src/entities/Enemy.ts
+++ b/src/entities/Enemy.ts
@@ -1,6 +1,7 @@
 import SheetSprite from "./SheetSprite";
 import Bullet from "./Bullet";
 import { ClipRect, getRandomArbitrary } from "../utils";
+import { playShootSound } from "../sound";
 
 export interface EnemyUpdateOptions {
   alienDirection: number;
@@ -54,6 +55,7 @@ export default class Enemy extends SheetSprite {
       -1,
       500,
     );
+    playShootSound();
   }
 
   update(dt: number, opts: EnemyUpdateOptions) {

--- a/src/entities/Player.ts
+++ b/src/entities/Player.ts
@@ -1,6 +1,7 @@
 import SheetSprite from "./SheetSprite";
 import Bullet from "./Bullet";
 import { ClipRect, clamp } from "../utils";
+import { playShootSound } from "../sound";
 
 export default class Player extends SheetSprite {
   lives: number;
@@ -57,6 +58,7 @@ export default class Player extends SheetSprite {
       1000,
     );
     this.bullets.push(bullet);
+    playShootSound();
   }
 
   handleInput() {

--- a/src/sound.ts
+++ b/src/sound.ts
@@ -1,0 +1,36 @@
+let audioCtx: AudioContext | null = null;
+
+export function playShootSound() {
+  if (!audioCtx) {
+    const AudioContext =
+      window.AudioContext || (window as any).webkitAudioContext;
+    audioCtx = new AudioContext();
+  }
+  const ctx = audioCtx;
+  if (!ctx) return;
+
+  const oscillator = ctx.createOscillator();
+  const gain = ctx.createGain();
+
+  oscillator.type = "square";
+  oscillator.frequency.value = 800;
+
+  gain.gain.setValueAtTime(0.1, ctx.currentTime);
+  gain.gain.exponentialRampToValueAtTime(0.001, ctx.currentTime + 0.1);
+
+  oscillator.connect(gain);
+  gain.connect(ctx.destination);
+
+  oscillator.start();
+  oscillator.stop(ctx.currentTime + 0.1);
+}
+
+export function unlockAudio() {
+  if (!audioCtx) {
+    const AudioContext =
+      window.AudioContext || (window as any).webkitAudioContext;
+    audioCtx = new AudioContext();
+  } else if (audioCtx.state === "suspended") {
+    audioCtx.resume();
+  }
+}


### PR DESCRIPTION
## Summary
- add Web Audio helper to generate shooting sound
- trigger sound when player or enemy fires

## Testing
- `npm test` (missing script: test)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a7bada7d8883239d58eb8073156656