### PR TITLE
feat: add audio toggle button

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,8 +1,28 @@
-import { useRef } from 'react';
+import { useRef, useState } from 'react';
 import { useSpaceInvaders } from './hooks/useSpaceInvaders';
+import { setSoundEnabled } from './sound';
 
 export default function App() {
   const canvasRef = useRef<HTMLCanvasElement>(null);
   useSpaceInvaders(canvasRef, { autoPlay: true });
-  return <canvas ref={canvasRef} />;
+
+  const [soundEnabled, setSoundEnabledState] = useState(true);
+
+  const toggleSound = () => {
+    const newEnabled = !soundEnabled;
+    setSoundEnabledState(newEnabled);
+    setSoundEnabled(newEnabled);
+  };
+
+  return (
+    <>
+      <canvas ref={canvasRef} />
+      <button
+        onClick={toggleSound}
+        style={{ position: 'absolute', top: 10, left: 10, zIndex: 1 }}
+      >
+        {soundEnabled ? 'Mute' : 'Unmute'}
+      </button>
+    </>
+  );
 }

--- a/src/sound.ts
+++ b/src/sound.ts
@@ -1,8 +1,26 @@
 import shootSoundSrc from "./assets/shoot.wav";
 
 let shootAudio: HTMLAudioElement | null = null;
+let soundEnabled = true;
+
+export function setSoundEnabled(enabled: boolean) {
+  soundEnabled = enabled;
+  if (enabled) {
+    unlockAudio();
+  } else if (shootAudio) {
+    shootAudio.pause();
+    shootAudio.currentTime = 0;
+  }
+}
+
+export function isSoundEnabled() {
+  return soundEnabled;
+}
 
 export function playShootSound() {
+  if (!soundEnabled) {
+    return;
+  }
   if (!shootAudio) {
     shootAudio = new Audio(shootSoundSrc);
   }


### PR DESCRIPTION
## Summary
- add setSoundEnabled and isSoundEnabled helpers so audio playback can be disabled
- gate playShootSound behind sound-enabled check
- add UI button to toggle sound on and off

## Testing
- `npm test` *(fails: Missing script "test" )*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a7c145bf3c8323a02527f9bcffb5b4